### PR TITLE
Fix VPP read and programming

### DIFF
--- a/src/eprom.cpp
+++ b/src/eprom.cpp
@@ -121,8 +121,8 @@ void eprom_write_init(firestarter_handle_t* handle) {
 void eprom_write_data(firestarter_handle_t* handle) {
 
     if (handle->firestarter_get_control_register(handle, REGULATOR) == 0) {
-        handle->firestarter_set_control_register(handle, REGULATOR, 1);
-        delay(100);
+        handle->firestarter_set_control_register(handle, REGULATOR | VPE_TO_VPP, 1); // Regulator defaults to VEP (~2V higher than VPP so it must be dropped)
+        delay(500);
     }
     uint8_t mismatch_bitmask[DATA_BUFFER_SIZE / 8];  // Array to store mismatch bits (32 bytes * 8 bits = 256 bits)
     int mismatch = 0;

--- a/src/firestarter.cpp
+++ b/src/firestarter.cpp
@@ -168,7 +168,7 @@ void readVoltage(firestarter_handle_t* handle) {
     handle->init = 0;
     uint8_t ctrl = read_from_register(CONTROL_REGISTER);
     if (handle->state == STATE_READ_VPP) {
-      write_to_register(CONTROL_REGISTER, ctrl | REGULATOR | VPE_TO_VPP | VPE_ENABLE);
+      write_to_register(CONTROL_REGISTER, ctrl | REGULATOR | VPE_TO_VPP ); //Only enable regulator and drop voltage to VPP
     }
     else if (handle->state == STATE_READ_VCC) {
       write_to_register(CONTROL_REGISTER, ctrl & ~REGULATOR);

--- a/src/uno_rurp_shield.cpp
+++ b/src/uno_rurp_shield.cpp
@@ -149,20 +149,19 @@ uint8_t read_data_buffer() {
 
 double rurp_read_voltage()
 {
-     double refRes = rurp_config.vcc / INPUT_RESOLUTION ;
+    double refRes = rurp_config.vcc / INPUT_RESOLUTION;
     
-    // float vin =13.53;
-    // float vout= 1.83;
-    // float k = vin / vout;
-
-    // return analogRead(VOLTAGE_MESSURE_PIN) * refRes * k;
-
     long r1 = rurp_config.r1;
     long r2 = rurp_config.r2;
     
-    double voltageDivider = ( r1 + r2) / r2;
-
-     return analogRead(VOLTAGE_MESSURE_PIN) * refRes * voltageDivider;
+    // Correct voltage divider ratio calculation
+    double voltageDivider = 1.0 + static_cast<double>(r1) / r2;
+    
+    // Read the analog value and convert to voltage
+    double vout = analogRead(VOLTAGE_MESSURE_PIN) * refRes;
+    
+    // Calculate the input voltage
+    return vout * voltageDivider;
 }
 
 double rurp_get_voltage_average()


### PR DESCRIPTION
…ogramming

Reading VPP now works as intended, VPP voltage is no longer applied to ROM during VPP read/calibration to avoid letting out magic smoke from 5V chips and VPE_to_VPP is set during programming (to drop the higher erasure voltage down to programming voltage). Init delay increased to 500ms to give VPP a better chance to settle.