### PR TITLE
Centralize issue tracking in firestarter_prom

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Central Firestarter issue tracker
+    url: https://github.com/henols/firestarter_prom/issues/new/choose
+    about: Report bugs, request features, ask for support, or coordinate cross-repository work here.

--- a/README.md
+++ b/README.md
@@ -3,18 +3,19 @@
 ---
 # Firestarter Firmware
 
+> [!IMPORTANT]
+> Bugs, feature requests, support requests, and project-wide work are tracked in the [central Firestarter issue tracker](https://github.com/henols/firestarter_prom/issues).
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 
 [![ko-fi](https://raw.githubusercontent.com/henols/firestarter_app/refs/heads/main/images/ko-fi.png)](https://ko-fi.com/E1E21I2WWW)
 
 ----
-The Firestarter Firmaware is intedend to be used with the [Firestarter application](https://github.com/henols/firestarter_app) and the [Relatively-Universal-ROM-Programmer](https://github.com/AndersBNielsen/Relatively-Universal-ROM-Programmer) RURP shield.
+The Firestarter Firmware is intended to be used with the [Firestarter application](https://github.com/henols/firestarter_app) and the [Relatively-Universal-ROM-Programmer](https://github.com/AndersBNielsen/Relatively-Universal-ROM-Programmer) RURP shield.
 
 
 For more information, see the [Firestarter README](https://github.com/henols/firestarter_app/blob/main/README.md).
 
 ## License
 [MIT](https://raw.githubusercontent.com/henols/firestarter/main/LICENSE)
-
-


### PR DESCRIPTION
Implements the repository-documentation portion of henols/firestarter_prom#6:

- directs bugs, feature requests, support, and cross-repository work to `henols/firestarter_prom/issues`
- adds an issue-template configuration that disables blank local issue forms and links to the canonical tracker
- corrects minor README spelling while touching the file

Repository-level disabling of GitHub Issues and `main` branch protection still require repository admin settings.