### PR TITLE
fix(uno): drain stray UART RX bytes after Serial.begin()

### DIFF
--- a/src/boards/uno_rurp_shield.cpp
+++ b/src/boards/uno_rurp_shield.cpp
@@ -85,6 +85,10 @@ void rurp_set_communication_mode() {
     PORTD |= 0x01;
     DDRD &= ~(0x01);
     rurp_serial_begin(MONITOR_SPEED);
+    // The ATmega16U2 USB-serial bridge can emit stray bytes to UART RX
+    // after UART init completes.  Wait for them to settle, then drain
+    // so loop() never sees them as a COBS frame.
+    delay(100);
     while (SERIAL_PORT.available()) SERIAL_PORT.read();
     com_mode = true;
 


### PR DESCRIPTION
## Problem

After boot (or any `rurp_set_communication_mode()` call), the Uno's COBS decoder in `loop()` sometimes picks up a stray byte that doesn't form a valid frame. This triggers `MSG_ERR_EMPTY_INPUT`, which on the host side arrives before the real OK ack and causes the connection probe to fail.

The host sees:


## Fix

Add a 100 ms settle delay after the initial UART RX flush in `rurp_set_communication_mode()`, then a second flush. This catches stray bytes that arrive after the first flush regardless of their origin.

## Root cause note

The exact source of the stray byte has not been confirmed with a logic analyser. It is likely a late byte from the ATmega16U2 USB-serial bridge that lands after the initial flush, but could also be an electrical glitch on PD0 during the DDR transition. The settle delay + second flush is harmless either way.

## Tested

Bench-tested on Uno R3 (ATmega16U2) with firmware 3.0.0b10 — the stale `MSG_ERR_EMPTY_INPUT` messages no longer appear.