### PR TITLE
ci: run gates on every branch, one publisher per branch

### DIFF
--- a/.github/workflows/beta-build.yml
+++ b/.github/workflows/beta-build.yml
@@ -85,11 +85,34 @@ jobs:
             --language cpp
           git diff --exit-code include/messages.h
 
+      # The vector-catalog pair below mirrors the messages.toml pair above and
+      # exists in build.yml already. They were absent here, so a beta push --
+      # the one push that produces a published artefact -- was the only path
+      # NOT checking frame_vectors.h for codegen drift. Added when build.yml
+      # stopped running on beta, so that removing the duplicate build does not
+      # quietly remove a gate along with it.
+      - name: Vector catalog validity check
+        run: python3 tools/catalog/codegen_vectors.py --catalog tools/catalog/frame-vectors.toml --check
+
+      - name: Codegen drift gate (frame_vectors.h)
+        run: |
+          python3 tools/catalog/codegen_vectors.py \
+            --catalog tools/catalog/frame-vectors.toml \
+            --target include/frame_vectors.h \
+            --language cpp-vectors
+          git diff --exit-code include/frame_vectors.h
+
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
 
       - name: Run native unit tests
         run: pio test -e native
+
+      # Same rationale as the vector gates above: -D DEV_TOOLS lives in the
+      # shared [env] block, so without this leg the no-DEV_TOOLS build is never
+      # compiled on the branch that ships.
+      - name: Run native unit tests (no DEV_TOOLS)
+        run: pio test -e native_nodevtools
 
       - name: Install pytest for script tests
         run: pip install pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,23 @@ jobs:
       contents: write
 
     steps:
+      # fetch-depth: 0 is REQUIRED, not hygiene. `pytest tests/ -v` below runs
+      # the Phase-123/129 history gates (check_landing_range, the flash-geometry
+      # ordering pair, the PR-45 ancestry pair). Every one of them walks git
+      # history: they resolve a fork SHA, and they assert that a commit touching
+      # a given path exists strictly after another commit. Under checkout's
+      # default shallow depth-1 clone those SHAs are not in the repository at
+      # all, and the gates fail with "does not resolve to a commit" rather than
+      # with anything about the code.
+      #
+      # This was invisible while the workflow ran on main only: main lags beta
+      # by a long way and does not carry those test files, so the step passed
+      # there for want of anything to run. Opening the trigger to every branch
+      # is what surfaced it. beta-build.yml already sets fetch-depth: 0 for the
+      # same reason -- this brings build.yml in line with it.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,24 @@
 name: Firestarter CI
+# Build + gates run on EVERY branch; only `main` publishes.
+#
+# This workflow used to trigger on main only, which meant a push to a
+# milestone or fix branch compiled nothing at all and a PR targeting `beta`
+# got no AVR CI whatsoever -- the branch was proven only when it reached
+# main, long after review. The trigger is now unrestricted.
+#
+# That reversal matters because three steps at the bottom of this job MUTATE
+# the repository or publish: the version bump, the git-auto-commit that
+# pushes it back to the branch, and the release upload with make_latest.
+# Their safety used to be implied entirely by the trigger. It is now explicit
+# -- each carries an `if:` naming push-to-main. Removing the branch filter
+# without those guards would auto-commit a version bump onto every feature
+# branch and publish a spurious "latest" stable release from it.
 on:
   push:
-    branches:
-    - main
+    # '**' matches every BRANCH but no tags. A bare `push:` would also fire
+    # on tag pushes, and this project pushes tags across all three repos at
+    # milestone close expecting zero CI from them.
+    branches: ['**']
     paths-ignore:
     - '**.md'
     - '**.sh'
@@ -13,8 +29,6 @@ on:
     - '.vscode/**'
     - '.editorconfig/**'
   pull_request:
-    branches:
-    - main
     paths-ignore:
     - '**.md'
     - '**.sh'
@@ -24,6 +38,14 @@ on:
     - 'images/**'
     - '.vscode/**'
     - '.editorconfig/**'
+
+# Broadening the trigger multiplies queued runs, and a same-repo PR branch now
+# matches both `push` and `pull_request`. Supersede stale runs per ref so the
+# queue does not starve -- but NEVER cancel on a publishing branch, where a
+# half-finished run could leave a tag without its assets.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/beta' }}
 
 jobs:
   build:
@@ -94,10 +116,12 @@ jobs:
       # behaves identically without -D DEV_TOOLS as it does with it -- a
       # no-DEV_TOOLS build had never been compiled or tested before this
       # milestone (-D DEV_TOOLS lives in the shared [env] block and is
-      # inherited by all three AVR envs AND [env:native]). This step will
-      # not fire on the v1.22 milestone branch (this workflow triggers on
-      # push/pull_request to main only); the in-phase proof is the local
-      # `pio test -e native_nodevtools` run recorded in 119-02-SUMMARY.md.
+      # inherited by all three AVR envs AND [env:native]). The note that used
+      # to sit here -- that this step would not fire on a milestone branch
+      # because the workflow triggered on main only, leaving a local run
+      # recorded in 119-02-SUMMARY.md as the sole proof -- no longer holds:
+      # the trigger now covers every branch, so milestone branches get this
+      # gate in CI rather than on someone's laptop.
       - name: Run native unit tests (no DEV_TOOLS)
         run: pio test -e native_nodevtools
 
@@ -108,20 +132,42 @@ jobs:
         run: pytest tests/ -v
 
       # --- Version bump + tag commit now gated by everything above ---
+      #
+      # PUBLISH BOUNDARY. Everything above this line runs on every branch and
+      # every PR; everything below runs ONLY on a push to main.
+      #
+      # `update_version.py` rewrites the tracked include/version.h in place, so
+      # skipping it off-main is harmless -- the build simply uses the committed
+      # version. It is gated anyway because its output feeds the two steps that
+      # follow, and leaving it ungated would put a dirty version.h in front of
+      # the auto-commit on branches where nothing should be committed at all.
       - name: Generate release version
         id: version
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: .github/scripts/update_version.py
 
+      # Pushes a commit back to the branch it ran on. Ungated on an
+      # unrestricted trigger this would land a version-bump commit on every
+      # feature branch -- and that commit is itself a push, so it would
+      # re-trigger this workflow.
       - uses: stefanzweifel/git-auto-commit-action@v5
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         # with:
         #   tagging_message: ${{ steps.version.outputs.version }}
         # env:
         #   GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
+      # Deliberately OUTSIDE the publish boundary: compiling every AVR env is
+      # the whole point of running on other branches. It stays after the bump
+      # so that on main the published .hex carries the bumped version.
       - name: Build PlatformIO Project
         run: pio run
 
+      # Creates a GitHub Release with make_latest: true. On any branch other
+      # than main this would publish a spurious "latest" stable release under
+      # whatever tag update_version.py produced.
       - name: Release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: softprops/action-gh-release@v2
         with:
           files: .pio/build/**/firestarter_*.hex

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,20 @@ on:
     # '**' matches every BRANCH but no tags. A bare `push:` would also fire
     # on tag pushes, and this project pushes tags across all three repos at
     # milestone close expecting zero CI from them.
-    branches: ['**']
+    #
+    # '!beta' keeps THIS workflow -- the STABLE publisher, the one holding the
+    # make_latest release -- off the beta branch entirely. beta has its own
+    # publisher in beta-build.yml, which builds the same targets and cuts the
+    # pre-release. Letting both fire on a beta push rebuilt everything twice
+    # and, worse, put the stable-release workflow on a branch that must never
+    # produce a stable release: the make_latest step is guarded by an `if:`,
+    # but a workflow that cannot run there cannot be one guard-edit away from
+    # publishing there either. Structural exclusion beats a conditional.
+    #
+    # This does NOT weaken PR coverage: `pull_request` below carries no branch
+    # filter, so a PR targeting beta still runs this workflow in full. Only the
+    # direct push to beta is excluded, and beta-build.yml covers that.
+    branches: ['**', '!beta']
     paths-ignore:
     - '**.md'
     - '**.sh'

--- a/.github/workflows/py32f071.yml
+++ b/.github/workflows/py32f071.yml
@@ -1,24 +1,31 @@
 name: PY32F071 firmware
 
 on:
-  # MERGE-03/D-05: push: branches: [beta] was implemented literally, with no
-  # paths filter, so any change anywhere that breaks the ARM configure is
-  # caught on beta. The double-ARM-build question this comment used to record
-  # for Phase 128 to resolve is RESOLVED by D-05: both builds stay, with
-  # distinct roles -- this workflow is the LOUD gate (no continue-on-error,
-  # red and staying red when ARM breaks on beta) and beta-build.yml's ARM
-  # steps are the SOFT copy (continue-on-error: true, existing only to
-  # produce the release asset, never able to block AVR). This pairing is what
-  # makes beta-build.yml's containment defensible; neither half is sound
-  # alone. continue-on-error comes off beta-build.yml's call site when the
-  # target is validated on real silicon; no PCB exists, so it is unreachable
-  # this milestone and the flag stays there. The push/pull_request/
-  # workflow_dispatch trigger blocks themselves change in no way --
-  # MERGE-03's trigger is preserved verbatim, which is
-  # precisely why ad47c3b was re-applied by hand rather than cherry-picked
-  # (128-03-SUMMARY.md).
+  # MERGE-03/D-05: this workflow is the LOUD ARM gate -- no continue-on-error,
+  # red and staying red when ARM breaks -- while beta-build.yml's ARM steps are
+  # the SOFT copy (continue-on-error: true, existing only to produce the
+  # release asset, never able to block AVR). That pairing is what makes
+  # beta-build.yml's containment defensible; neither half is sound alone.
+  # continue-on-error comes off beta-build.yml's call site when the target is
+  # validated on real silicon; no PCB exists, so it is unreachable and the flag
+  # stays there.
+  #
+  # SUPERSEDES the MERGE-03 note that used to live here recording the trigger
+  # as "preserved verbatim" (128-03-SUMMARY.md). `push: branches: [beta]`
+  # meant ARM was only proven once work reached beta -- a push to a milestone
+  # or fix branch built nothing, so an ARM break was found at merge time
+  # rather than when it was written. The push filter is removed; the loud gate
+  # now runs wherever the code is.
+  #
+  # This workflow publishes nothing. Its two upload-artifact steps attach
+  # ephemeral build output to the run itself -- they are not releases, and
+  # keeping them on every branch is the point: the .hex is most useful to
+  # download exactly when the work is still on a branch. The release ASSET is
+  # produced by beta-build.yml, which remains beta-only.
+  # '**' matches every BRANCH but no tags -- milestone-close tag pushes must
+  # still fire zero CI.
   push:
-    branches: [beta]
+    branches: ['**']
   pull_request:
     paths:
       - "platform/py32f071/**"
@@ -27,6 +34,13 @@ on:
       - "lib/jsmn/**"
       - ".github/workflows/py32f071.yml"
   workflow_dispatch:
+
+# A same-repo PR branch now matches both `push` and the path-filtered
+# `pull_request`, so supersede stale runs per ref rather than queueing both to
+# completion. Never cancel on a publishing branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/beta' }}
 
 jobs:
   build:


### PR DESCRIPTION
Three commits. The first opens the triggers; the other two are fixes for things that opening them exposed.

## The problem

Both firmware workflows that compile code were branch-restricted, so **a push to a milestone or fix branch built nothing**. AVR gates ran on `main` only, the ARM gate on `beta` only. A break surfaced at merge time rather than when it was written — and a PR targeting `beta` got no AVR CI at all, which is exactly what happened to #49.

## Resulting shape

```
push beta   -> beta-build.yml (publishes pre-release) + py32f071.yml
push main   -> build.yml      (publishes stable)      + py32f071.yml
push branch -> build.yml      (gates + build, publish SKIPPED) + py32f071.yml
PR any base -> build.yml + py32f071.yml, never publishes
```

One publisher per branch. No path publishes twice.

## `99fa244` — open the triggers, make publishing explicit

Three steps in `build.yml` **mutate the repo or publish**, and their safety was implied entirely by the main-only trigger. Each now carries `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`.

This also closes a **latent duplicate-publish bug that predates this PR**. On `beta` today, `build.yml` triggers on `pull_request: [main]` with all three steps *ungated* — so every PR into `main` would bump the version, **auto-commit onto the PR branch**, and cut a `make_latest` release. Merging then republishes the same version derived from the same `include/version.h`, and the second publish is rejected. Rare enough never to have bitten, but armed. PR runs can no longer publish at all.

Verified on a real run: steps 15/16/18 return `skipped` on a feature-branch push, while the build still runs.

`branches: ['**']` rather than a bare `push:` — a bare trigger also fires on **tag** pushes, and this project pushes tags across three repos at milestone close expecting zero CI.

A `concurrency` group per workflow supersedes stale runs, with `cancel-in-progress` explicitly **false** on main and beta so two rapid pushes to a publishing branch queue instead of racing.

## `665ba99` — `fetch-depth: 0`, caught by the change itself

Opening the trigger made `pytest tests/ -v` run against beta-derived branches for the first time. It failed immediately:

```
FIRESTARTER_RANGE_FORK='5c9160a...' does not resolve to a commit
no commit touching 'platform/py32f071/linker/PY32F071xB_FLASH.ld' exists strictly after 40b11eb...
```

Not a code failure. The Phase-123/129 gates walk git history, and `actions/checkout@v4` defaults to a shallow depth-1 clone. Invisible before because `build.yml` ran on `main` only, and main lags beta far enough not to carry those test files — the step passed for want of anything to run. `beta-build.yml` has carried `fetch-depth: 0` all along.

## `25235c4` — keep the stable publisher off beta, backfill beta's gates

`['**']` made `build.yml` fire on beta pushes alongside `beta-build.yml`. No double-publish occurred (the guards held), but it rebuilt every AVR target twice, and put the **stable-release workflow on a branch that must never cut a stable release** — one `if:` edit away from doing so. Structural exclusion beats a conditional for something that consequential: the trigger is now `['**', '!beta']`.

PR coverage is untouched — `pull_request` has no branch filter, so a PR into beta still runs this workflow in full. Only the direct push to beta is excluded.

Removing the duplicate build would have silently removed **gate** coverage too, so three checks only `build.yml` had are backfilled into `beta-build.yml`:

- Vector catalog validity check
- Codegen drift gate (`frame_vectors.h`)
- Native unit tests (no `DEV_TOOLS`)

Stated plainly: before this, a beta push — the one push that produces a published artefact — was the **only** path not checking `frame_vectors.h` for codegen drift, and never compiled the no-`DEV_TOOLS` build.

## Verification

`Firestarter CI` and `PY32F071 firmware` both **pass on `push` and on `pull_request`**. The publish boundary is confirmed by observed step results, not by argument:

```
14. Run update_version.py tests ....... success   <- fetch-depth fix
15. Generate release version .......... skipped
16. git-auto-commit-action ............ skipped
17. Build PlatformIO Project .......... success   <- deliberately outside the boundary
18. Release ........................... skipped
```

**Merge before #49** — until this lands, #49's branch still carries `pull_request: branches: [main]`, so the AVR gate cannot reach it and it is proven by ARM only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)