### PR TITLE
ci: cut a firmware pre-release on every merge to beta

### DIFF
--- a/.github/workflows/beta-build.yml
+++ b/.github/workflows/beta-build.yml
@@ -1,17 +1,30 @@
 name: Firestarter beta pre-release build
 on:
+  # EVERY merge to beta cuts a pre-release. The paths-ignore list that used to
+  # sit here ('**.md', '**.sh', '.gitignore', 'docs/**', 'documents/**',
+  # 'images/**', '.vscode/**', '.editorconfig/**') meant a merge touching only
+  # those paths bumped no version and published nothing, leaving the published
+  # beta not corresponding to the beta branch.
+  #
+  # That matters more here than in the host repo, because the version is
+  # COMPILED IN: FW_VERSION comes from include/version.h, which only changes
+  # when the bump below runs. A beta commit that skipped the bump would build
+  # firmware reporting the PREVIOUS release's version -- a binary that
+  # misreports which version it is, and a host-side version gate reading a
+  # number that does not identify the code it is talking to.
+  #
+  # Matches beta-release.yml in firestarter_app, which dropped the same filter
+  # for the same reason. Constant version bumping on beta is explicitly
+  # acceptable: beta is a moving pre-release channel, not a curated one.
+  #
+  # No publish loop, and this is settled by evidence rather than by reasoning
+  # about GITHUB_TOKEN semantics: the "Apply automatic changes" auto-commit
+  # below writes include/version.h, which was NEVER in the removed list. If a
+  # GITHUB_TOKEN push could trigger this workflow, commit 66c3101 on beta
+  # would have started a second run. It started none.
   push:
     branches:
     - beta
-    paths-ignore:
-    - '**.md'
-    - '**.sh'
-    - '.gitignore'
-    - 'docs/**'
-    - 'documents/**'
-    - 'images/**'
-    - '.vscode/**'
-    - '.editorconfig/**'
   workflow_dispatch:
     inputs:
       beta_version:


### PR DESCRIPTION
Companion to henols/firestarter_app#48, which drops the same filter in the host repo for the same reason.

## The bug

`beta-build.yml` carried a `paths-ignore` list:

```
'**.md'  '**.sh'  '.gitignore'  'docs/**'  'documents/**'  'images/**'  '.vscode/**'  '.editorconfig/**'
```

A merge touching **only** those paths bumped no version and published nothing, so the published beta stopped corresponding to the beta branch.

## Why this is worse for firmware than for the host

**The version is compiled in.** `FW_VERSION` comes from `include/version.h`, which only changes when the bump step runs. A beta commit that skipped the bump would build firmware **reporting the previous release's version** — a binary that misreports which version it is, and a host-side version gate reading a number that doesn't identify the code it's talking to.

The host degrades to a package whose metadata is merely stale. The firmware ships the wrong answer *inside the image*.

## No publish loop — settled by evidence

Not by reasoning about `GITHUB_TOKEN` semantics. The `Apply automatic changes` auto-commit writes `include/version.h`, which was **never** in the removed list. If a `GITHUB_TOKEN` push could trigger this workflow, commit `66c3101` on beta would have started a second run.

It started none. One `Firestarter beta pre-release build` on beta today, at `09:08:05`.

## Consequence worth stating

Docs-only merges to beta will now also cut a pre-release with the full four-asset set (`uno`, `uno328pb`, `leonardo`, `py32f071`). That is the intent — beta is a moving pre-release channel, not a curated one, and constant version bumping there is explicitly acceptable.

## Resulting state across both repos

| repo | workflow | push branches | path filter |
|---|---|---|---|
| fw | `beta-build.yml` | `[beta]` | **none** |
| app | `beta-release.yml` | `[beta]` | **none** |
| fw | `build.yml` | `['**', '!beta']` | yes (gates only; publishes on main) |
| app | `ci.yml` | `['**']` | yes (publishes nothing) |
| app | `release.yml` | `[main]` | yes (stable, operator-gated) |

Both beta publishers now agree. `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)