### PR TITLE
Add contribution pointer

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+# Contributing
+
+The Firestarter project's contribution policy lives on the wiki:
+[Contributing](https://github.com/henols/firestarter_prom/wiki/Contributing).
+
+That page covers where to report a problem, where to open a pull request, and how a change spanning more than one repository is coordinated.


### PR DESCRIPTION
Adds `.github/CONTRIBUTING.md`, pointing contributors at the canonical [Contributing](https://github.com/henols/firestarter_prom/wiki/Contributing) wiki page.

GitHub reads `CONTRIBUTING.md` only from the repository where a pull request or issue is opened, which is why each repository needs its own copy.