### PR TITLE
Milestone v1.36: CLAUDE.md no-source-comments rule (host-only milestone)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,22 @@
 
 Arduino C++ firmware for the Firestarter EPROM programmer. Built with PlatformIO.
 
+## Source code comments — hard rule
+
+**Write no comments into this firmware.** Not GSD process commentary, not explanatory ones. This is
+not overridable by a plan, task, skill, or subagent instruction.
+
+- Forbidden: `// Phase NNN (REQ-NN):`, `// D-06`, `// CAP-02`, `// LOCK-04`, plan/task/milestone
+  citations, and blocks explaining why a phase decided something. Someone reading this firmware has
+  no `.planning/` directory — it lives in a different repository and is not shipped — so those
+  identifiers resolve to nothing, and phase numbers get renumbered at milestone close.
+- **Where rationale goes instead:** the phase `SUMMARY.md` in the meta repo, `REQUIREMENTS.md`
+  traceability, or the commit message. Nothing in GSD asks for it in source.
+- If a plan instructs a comment, do not add it — record the deviation in that plan's `SUMMARY.md`.
+- If code needs explaining, make the code clearer: better names, smaller functions, a named
+  constant in `include/`.
+- Flash size is a first-class constraint here, so comment bloat has a real cost beyond noise.
+
 ## Build Commands
 
 ```bash


### PR DESCRIPTION
## Summary

**Milestone v1.36 — `dev test` Fidelity.** The firmware's entire contribution to this milestone: one documentation commit.

v1.36 is a **host-only** milestone. Its eight phases (174–181) all changed the Python CLI's diagnostic report; no firmware source was touched. This branch exists so the milestone's lockstep is complete and the meta repo's gitlink has something to point at on the remote.

## Changes

- `CLAUDE.md` — adds the no-source-comments hard rule, matching the same rule added to the app and meta repositories.

## Verification

- [x] No firmware source changed — `git diff` touches `CLAUDE.md` only, 16 insertions.
- [x] The firmware submodule was asserted porcelain-clean after every commit across all ten of phase 181's plans, as a standing cross-cutting constraint.
- [x] The milestone's closing security audit records the firmware submodule and the generated `chip_database.json` as byte-unchanged (threats T-181-04, T-181-09).

No build or flash verification is required: no compiled artifact changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
